### PR TITLE
feat(quiz): add matching, ordering, coding, and essay question types

### DIFF
--- a/backend/src/modules/quiz/quiz-generator.service.ts
+++ b/backend/src/modules/quiz/quiz-generator.service.ts
@@ -1,7 +1,25 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AiService } from '../ai/ai.service';
 
-export type QuestionType = 'multiple_choice' | 'true_false' | 'short_answer' | 'fill_blank';
+export type QuestionType =
+  | 'multiple_choice'
+  | 'true_false'
+  | 'short_answer'
+  | 'fill_blank'
+  | 'matching'
+  | 'ordering'
+  | 'coding'
+  | 'essay';
+
+export interface MatchingPair {
+  left: string;
+  right: string;
+}
+
+export interface CodingTestCase {
+  input: string;
+  expected: string;
+}
 
 export interface GeneratedQuestion {
   type: QuestionType;
@@ -10,6 +28,20 @@ export interface GeneratedQuestion {
   correctAnswer: string;
   explanation: string;
   difficulty: 'easy' | 'medium' | 'hard';
+  /** For matching questions: pairs of left-right items */
+  pairs?: MatchingPair[];
+  /** For ordering questions: items to order */
+  items?: string[];
+  /** For ordering questions: correct order as indices */
+  correctOrder?: number[];
+  /** For coding questions: programming language */
+  language?: string;
+  /** For coding questions: test cases */
+  testCases?: CodingTestCase[];
+  /** For essay questions: grading rubric */
+  rubric?: string;
+  /** For essay questions: maximum word count */
+  maxWords?: number;
 }
 
 export interface GenerateQuizOptions {
@@ -52,15 +84,36 @@ Return the questions in this exact JSON format:
 {
   "questions": [
     {
-      "type": "multiple_choice" | "true_false" | "short_answer" | "fill_blank",
+      "type": "multiple_choice" | "true_false" | "short_answer" | "fill_blank" | "matching" | "ordering" | "coding" | "essay",
       "question": "The question text",
       "options": ["A", "B", "C", "D"], // only for multiple_choice
-      "correctAnswer": "The correct answer",
+      "correctAnswer": "The correct answer", // for multiple_choice, true_false, short_answer, fill_blank
       "explanation": "Why this is correct",
-      "difficulty": "easy" | "medium" | "hard"
+      "difficulty": "easy" | "medium" | "hard",
+
+      // For matching questions only:
+      "pairs": [{"left": "Term", "right": "Definition"}, ...], // 4-6 pairs to match
+
+      // For ordering questions only:
+      "items": ["Step 1", "Step 2", "Step 3"], // items in correct order
+      "correctOrder": [0, 1, 2], // indices representing the correct sequence
+
+      // For coding questions only:
+      "language": "python", // programming language
+      "testCases": [{"input": "...", "expected": "..."}], // test cases for validation
+
+      // For essay questions only:
+      "rubric": "Key points: X, Y, Z", // grading criteria
+      "maxWords": 500 // maximum word count
     }
   ]
-}`;
+}
+
+Important type-specific rules:
+- matching: Always include "pairs" array with 4-6 items. Set "correctAnswer" to JSON string of the pairs array.
+- ordering: Always include "items" and "correctOrder". Set "correctAnswer" to JSON string of correctOrder array.
+- coding: Always include "language", "testCases" with at least 2 test cases. Set "correctAnswer" to a sample solution.
+- essay: Always include "rubric" and "maxWords". Set "correctAnswer" to key points expected.`;
 
     const userPrompt = `Study Material:
 ${content}
@@ -123,15 +176,23 @@ Return the questions in this exact JSON format:
 {
   "questions": [
     {
-      "type": "multiple_choice" | "true_false" | "short_answer",
+      "type": "multiple_choice" | "true_false" | "short_answer" | "fill_blank" | "matching" | "ordering" | "coding" | "essay",
       "question": "The question text",
       "options": ["A", "B", "C", "D"],
       "correctAnswer": "The correct answer",
       "explanation": "Why this is correct",
-      "difficulty": "${difficulty}"
+      "difficulty": "${difficulty}",
+      "pairs": [{"left": "Term", "right": "Definition"}, ...],
+      "items": ["Step 1", "Step 2", "Step 3"],
+      "correctOrder": [0, 1, 2],
+      "language": "python",
+      "testCases": [{"input": "...", "expected": "..."}],
+      "rubric": "Key points: X, Y, Z",
+      "maxWords": 500
     }
   ]
-}`;
+}
+Include only the fields relevant to each question type.`;
 
     const response = await this.aiService.completeJson<{ questions: GeneratedQuestion[] }>(
       [

--- a/backend/src/modules/quiz/quiz.module.ts
+++ b/backend/src/modules/quiz/quiz.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { CodeSandboxModule } from '../code-sandbox/code-sandbox.module';
 import { QuizService } from './quiz.service';
 import { QuizController } from './quiz.controller';
 import { QuizGeneratorService } from './quiz-generator.service';
@@ -8,7 +9,7 @@ import { LiveQuizService } from './live-quiz.service';
 import { LiveQuizGateway } from './live-quiz.gateway';
 
 @Module({
-  imports: [AuthModule, NotificationsModule],
+  imports: [AuthModule, NotificationsModule, CodeSandboxModule],
   controllers: [QuizController],
   providers: [QuizService, QuizGeneratorService, LiveQuizService, LiveQuizGateway],
   exports: [QuizService, QuizGeneratorService, LiveQuizService],

--- a/backend/src/modules/quiz/quiz.service.ts
+++ b/backend/src/modules/quiz/quiz.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { DatabaseService } from '../database/database.service';
-import { QuizGeneratorService, QuestionType } from './quiz-generator.service';
+import { QuizGeneratorService, QuestionType, MatchingPair, CodingTestCase } from './quiz-generator.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { CodeSandboxService } from '../code-sandbox/code-sandbox.service';
+import { AiService } from '../ai/ai.service';
 
 export interface Quiz {
   id: string;
@@ -27,6 +29,8 @@ export interface QuizQuestion {
   explanation: string | null;
   difficulty: string;
   order: number;
+  /** JSON metadata for advanced question types (matching pairs, ordering items, coding test cases, essay rubric) */
+  metadata: Record<string, unknown> | null;
 }
 
 export interface QuizAttempt {
@@ -46,6 +50,10 @@ export interface QuizAttemptAnswer {
   questionId: string;
   userAnswer: string;
   isCorrect: boolean;
+  /** Partial credit score from 0.0 to 1.0 (1.0 = fully correct) */
+  score: number;
+  /** AI feedback for essay questions */
+  feedback: string | null;
   timeSpent: number;
 }
 
@@ -62,6 +70,20 @@ export interface CreateQuizDto {
     correctAnswer: string;
     explanation?: string;
     difficulty?: string;
+    /** Matching pairs for matching questions */
+    pairs?: MatchingPair[];
+    /** Items for ordering questions */
+    items?: string[];
+    /** Correct order indices for ordering questions */
+    correctOrder?: number[];
+    /** Programming language for coding questions */
+    language?: string;
+    /** Test cases for coding questions */
+    testCases?: CodingTestCase[];
+    /** Grading rubric for essay questions */
+    rubric?: string;
+    /** Max word count for essay questions */
+    maxWords?: number;
   }>;
 }
 
@@ -91,6 +113,8 @@ export class QuizService {
     private readonly db: DatabaseService,
     private readonly quizGenerator: QuizGeneratorService,
     private readonly notificationsService: NotificationsService,
+    private readonly codeSandboxService: CodeSandboxService,
+    private readonly aiService: AiService,
   ) {}
 
   async create(userId: string, dto: CreateQuizDto): Promise<Quiz> {
@@ -161,6 +185,13 @@ export class QuizService {
         correctAnswer: q.correctAnswer,
         explanation: q.explanation,
         difficulty: q.difficulty,
+        pairs: q.pairs,
+        items: q.items,
+        correctOrder: q.correctOrder,
+        language: q.language,
+        testCases: q.testCases,
+        rubric: q.rubric,
+        maxWords: q.maxWords,
       })),
     });
 
@@ -226,7 +257,7 @@ export class QuizService {
     const questions = await this.getQuestions(quizId);
     const questionMap = new Map(questions.map((q) => [q.id, q]));
 
-    let correctCount = 0;
+    let totalScore = 0;
     const attemptId = uuidv4();
     const now = new Date();
 
@@ -240,17 +271,26 @@ export class QuizService {
       const question = questionMap.get(answer.questionId);
       if (!question) continue;
 
-      const isCorrect = this.checkAnswer(question, answer.answer);
-      if (isCorrect) correctCount++;
+      const result = await this.checkAnswer(question, answer.answer, userId);
+      totalScore += result.score;
 
       await this.db.query(
-        `INSERT INTO quiz_attempt_answers (id, attempt_id, question_id, user_answer, is_correct, time_spent)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-        [uuidv4(), attemptId, answer.questionId, answer.answer, isCorrect, answer.timeSpent],
+        `INSERT INTO quiz_attempt_answers (id, attempt_id, question_id, user_answer, is_correct, score, feedback, time_spent)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [
+          uuidv4(),
+          attemptId,
+          answer.questionId,
+          answer.answer,
+          result.isCorrect,
+          result.score,
+          result.feedback || null,
+          answer.timeSpent,
+        ],
       );
     }
 
-    const score = (correctCount / questions.length) * 100;
+    const score = (totalScore / questions.length) * 100;
 
     await this.db.query(
       `UPDATE quiz_attempts SET score = $1, total_questions = $2, completed_at = $3 WHERE id = $4`,
@@ -263,6 +303,7 @@ export class QuizService {
     );
 
     // Send notification based on score
+    const correctCount = Math.round(totalScore);
     await this.sendQuizCompletionNotification(userId, score, correctCount, questions.length);
 
     this.logger.log(`Quiz attempt submitted: ${attemptId}, score: ${score.toFixed(1)}%`);
@@ -336,12 +377,43 @@ export class QuizService {
       correctAnswer: string;
       explanation?: string;
       difficulty?: string;
+      pairs?: MatchingPair[];
+      items?: string[];
+      correctOrder?: number[];
+      language?: string;
+      testCases?: CodingTestCase[];
+      rubric?: string;
+      maxWords?: number;
     },
     order: number,
   ): Promise<void> {
+    // Build metadata object for advanced question types
+    let metadata: Record<string, unknown> | null = null;
+
+    switch (question.type) {
+      case 'matching':
+        metadata = { pairs: question.pairs || [] };
+        break;
+      case 'ordering':
+        metadata = { items: question.items || [], correctOrder: question.correctOrder || [] };
+        break;
+      case 'coding':
+        metadata = {
+          language: question.language || 'python',
+          testCases: question.testCases || [],
+        };
+        break;
+      case 'essay':
+        metadata = {
+          rubric: question.rubric || '',
+          maxWords: question.maxWords || 500,
+        };
+        break;
+    }
+
     await this.db.query(
-      `INSERT INTO quiz_questions (id, quiz_id, type, question, options, correct_answer, explanation, difficulty, "order")
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      `INSERT INTO quiz_questions (id, quiz_id, type, question, options, correct_answer, explanation, difficulty, "order", metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
       [
         uuidv4(),
         quizId,
@@ -352,6 +424,7 @@ export class QuizService {
         question.explanation || null,
         question.difficulty || 'medium',
         order,
+        metadata ? JSON.stringify(metadata) : null,
       ],
     );
   }
@@ -397,9 +470,234 @@ export class QuizService {
     }
   }
 
-  private checkAnswer(question: QuizQuestion, userAnswer: string): boolean {
+  private async checkAnswer(
+    question: QuizQuestion,
+    userAnswer: string,
+    userId: string,
+  ): Promise<{ isCorrect: boolean; score: number; feedback?: string }> {
     const normalize = (s: string) => s.toLowerCase().trim();
-    return normalize(question.correctAnswer) === normalize(userAnswer);
+
+    switch (question.type) {
+      case 'matching':
+        return this.checkMatchingAnswer(question, userAnswer);
+
+      case 'ordering':
+        return this.checkOrderingAnswer(question, userAnswer);
+
+      case 'coding':
+        return this.checkCodingAnswer(question, userAnswer, userId);
+
+      case 'essay':
+        return this.checkEssayAnswer(question, userAnswer);
+
+      default: {
+        // Legacy types: multiple_choice, true_false, short_answer, fill_blank
+        const isCorrect = normalize(question.correctAnswer) === normalize(userAnswer);
+        return { isCorrect, score: isCorrect ? 1.0 : 0.0 };
+      }
+    }
+  }
+
+  /**
+   * Grade a matching question with partial credit.
+   * Each correct pair = 1/N of total score.
+   */
+  private checkMatchingAnswer(
+    question: QuizQuestion,
+    userAnswer: string,
+  ): { isCorrect: boolean; score: number } {
+    try {
+      const metadata = question.metadata as { pairs?: MatchingPair[] } | null;
+      const correctPairs: MatchingPair[] = metadata?.pairs || [];
+
+      if (correctPairs.length === 0) {
+        // Fallback to simple string comparison
+        const normalize = (s: string) => s.toLowerCase().trim();
+        const isCorrect = normalize(question.correctAnswer) === normalize(userAnswer);
+        return { isCorrect, score: isCorrect ? 1.0 : 0.0 };
+      }
+
+      const userMatches: { matches: MatchingPair[] } = JSON.parse(userAnswer);
+      const correctMap = new Map(correctPairs.map((p) => [p.left.toLowerCase().trim(), p.right.toLowerCase().trim()]));
+
+      let correctCount = 0;
+      for (const match of userMatches.matches) {
+        const expected = correctMap.get(match.left.toLowerCase().trim());
+        if (expected && expected === match.right.toLowerCase().trim()) {
+          correctCount++;
+        }
+      }
+
+      const score = correctPairs.length > 0 ? correctCount / correctPairs.length : 0;
+      return { isCorrect: score === 1.0, score };
+    } catch {
+      return { isCorrect: false, score: 0.0 };
+    }
+  }
+
+  /**
+   * Grade an ordering question with partial credit.
+   * Each correctly-placed item = 1/N of total score.
+   */
+  private checkOrderingAnswer(
+    question: QuizQuestion,
+    userAnswer: string,
+  ): { isCorrect: boolean; score: number } {
+    try {
+      const metadata = question.metadata as { items?: string[]; correctOrder?: number[] } | null;
+      const correctOrder: number[] = metadata?.correctOrder || [];
+
+      if (correctOrder.length === 0) {
+        const normalize = (s: string) => s.toLowerCase().trim();
+        const isCorrect = normalize(question.correctAnswer) === normalize(userAnswer);
+        return { isCorrect, score: isCorrect ? 1.0 : 0.0 };
+      }
+
+      const userOrder: { order: number[] } = JSON.parse(userAnswer);
+
+      let correctCount = 0;
+      for (let i = 0; i < correctOrder.length; i++) {
+        if (userOrder.order[i] === correctOrder[i]) {
+          correctCount++;
+        }
+      }
+
+      const score = correctOrder.length > 0 ? correctCount / correctOrder.length : 0;
+      return { isCorrect: score === 1.0, score };
+    } catch {
+      return { isCorrect: false, score: 0.0 };
+    }
+  }
+
+  /**
+   * Grade a coding question by running code against test cases via the code-sandbox service.
+   * Each passing test case = 1/N of total score.
+   */
+  private async checkCodingAnswer(
+    question: QuizQuestion,
+    userAnswer: string,
+    userId: string,
+  ): Promise<{ isCorrect: boolean; score: number; feedback?: string }> {
+    try {
+      const metadata = question.metadata as { language?: string; testCases?: CodingTestCase[] } | null;
+      const testCases = metadata?.testCases || [];
+      const language = metadata?.language || 'python';
+
+      if (testCases.length === 0) {
+        return { isCorrect: false, score: 0.0, feedback: 'No test cases defined for this question.' };
+      }
+
+      const parsed: { code: string } = JSON.parse(userAnswer);
+      const code = parsed.code;
+
+      let passedCount = 0;
+      const feedbackLines: string[] = [];
+
+      for (let i = 0; i < testCases.length; i++) {
+        const tc = testCases[i];
+        const result = await this.codeSandboxService.execute(userId, {
+          code,
+          language,
+          stdin: tc.input,
+          timeout: 10000,
+        });
+
+        const actualOutput = result.output.trim();
+        const expectedOutput = tc.expected.trim();
+
+        if (result.status === 'success' && actualOutput === expectedOutput) {
+          passedCount++;
+          feedbackLines.push(`Test ${i + 1}: PASSED`);
+        } else if (result.status === 'error' || result.status === 'timeout') {
+          feedbackLines.push(`Test ${i + 1}: FAILED — ${result.error || result.status}`);
+        } else {
+          feedbackLines.push(`Test ${i + 1}: FAILED — expected "${expectedOutput}", got "${actualOutput}"`);
+        }
+      }
+
+      const score = testCases.length > 0 ? passedCount / testCases.length : 0;
+      return {
+        isCorrect: score === 1.0,
+        score,
+        feedback: feedbackLines.join('\n'),
+      };
+    } catch (error) {
+      return {
+        isCorrect: false,
+        score: 0.0,
+        feedback: `Failed to evaluate code: ${(error as Error).message}`,
+      };
+    }
+  }
+
+  /**
+   * Grade an essay question using AI to evaluate against the rubric.
+   * Returns a score from 0.0 to 1.0 and textual feedback.
+   */
+  private async checkEssayAnswer(
+    question: QuizQuestion,
+    userAnswer: string,
+  ): Promise<{ isCorrect: boolean; score: number; feedback?: string }> {
+    try {
+      const metadata = question.metadata as { rubric?: string; maxWords?: number } | null;
+      const rubric = metadata?.rubric || question.correctAnswer;
+      const maxWords = metadata?.maxWords || 500;
+
+      const parsed: { text: string } = JSON.parse(userAnswer);
+      const essayText = parsed.text;
+
+      const wordCount = essayText.split(/\s+/).filter(Boolean).length;
+      if (wordCount > maxWords * 1.2) {
+        return {
+          isCorrect: false,
+          score: 0.0,
+          feedback: `Essay exceeds the maximum word count of ${maxWords} words (${wordCount} words submitted).`,
+        };
+      }
+
+      const response = await this.aiService.completeJson<{
+        score: number;
+        feedback: string;
+      }>(
+        [
+          {
+            role: 'system',
+            content: `You are an expert educational grader. Evaluate the student's essay answer against the rubric provided.
+
+Return a JSON object with:
+- "score": a number from 0 to 100 representing the percentage score
+- "feedback": constructive feedback explaining the grade, highlighting strengths and areas for improvement
+
+Be fair but rigorous. Partial credit is expected for partially correct answers.`,
+          },
+          {
+            role: 'user',
+            content: `Question: ${question.question}
+
+Rubric / Key Points: ${rubric}
+
+Student's Answer:
+${essayText}
+
+Grade this essay.`,
+          },
+        ],
+        { maxTokens: 1024 },
+      );
+
+      const normalizedScore = Math.max(0, Math.min(1, response.score / 100));
+      return {
+        isCorrect: normalizedScore >= 0.7,
+        score: normalizedScore,
+        feedback: response.feedback,
+      };
+    } catch (error) {
+      return {
+        isCorrect: false,
+        score: 0.0,
+        feedback: `Failed to evaluate essay: ${(error as Error).message}`,
+      };
+    }
   }
 
   private mapQuiz(row: unknown): Quiz {
@@ -420,6 +718,10 @@ export class QuizService {
 
   private mapQuestion(row: unknown): QuizQuestion {
     const r = row as Record<string, unknown>;
+    let metadata: Record<string, unknown> | null = null;
+    if (r.metadata) {
+      metadata = typeof r.metadata === 'string' ? JSON.parse(r.metadata) : (r.metadata as Record<string, unknown>);
+    }
     return {
       id: r.id as string,
       quizId: r.quiz_id as string,
@@ -434,6 +736,7 @@ export class QuizService {
       explanation: r.explanation as string | null,
       difficulty: r.difficulty as string,
       order: r.order as number,
+      metadata,
     };
   }
 
@@ -459,6 +762,8 @@ export class QuizService {
       questionId: r.question_id as string,
       userAnswer: r.user_answer as string,
       isCorrect: r.is_correct as boolean,
+      score: parseFloat(String(r.score ?? (r.is_correct ? 1.0 : 0.0))),
+      feedback: (r.feedback as string) || null,
       timeSpent: r.time_spent as number,
     };
   }


### PR DESCRIPTION
## Summary
- Adds 4 new question types (`matching`, `ordering`, `coding`, `essay`) to the quiz system, expanding from 4 to 8 supported types
- Implements partial credit scoring for matching (per-pair) and ordering (per-position) questions
- Integrates code-sandbox service for auto-grading coding questions against test cases
- Integrates AI service for rubric-based essay evaluation with score + feedback
- Updates the AI quiz generator prompts to produce all 8 question types
- New types are premium-only (existing `FREE_QUIZ_TYPES` gate unchanged)

## Changes
- `quiz-generator.service.ts` — Extended `QuestionType` union, added metadata interfaces (`MatchingPair`, `CodingTestCase`), updated AI generation prompts with new type schemas
- `quiz.service.ts` — Added `CodeSandboxService` and `AiService` dependencies, `metadata` field on `QuizQuestion`, `score`/`feedback` fields on `QuizAttemptAnswer`, new grading methods (`checkMatchingAnswer`, `checkOrderingAnswer`, `checkCodingAnswer`, `checkEssayAnswer`) with partial credit
- `quiz.module.ts` — Imported `CodeSandboxModule`

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with 0 errors
- [ ] Create a quiz with matching questions and verify partial credit scoring
- [ ] Create a quiz with ordering questions and verify position-based partial credit
- [ ] Create a quiz with coding questions and verify test case execution via sandbox
- [ ] Create a quiz with essay questions and verify AI-graded rubric evaluation
- [ ] Verify existing question types (multiple_choice, true_false, short_answer, fill_blank) still work unchanged
- [ ] Verify free users cannot generate new advanced question types

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)