### PR TITLE
feat(study-groups): add study groups and collaboration

### DIFF
--- a/backend/migrations/015_study_groups.sql
+++ b/backend/migrations/015_study_groups.sql
@@ -1,0 +1,49 @@
+-- Study groups table
+CREATE TABLE IF NOT EXISTS study_groups (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    invite_code VARCHAR(6) NOT NULL UNIQUE,
+    is_private BOOLEAN DEFAULT FALSE,
+    created_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Study group members table
+CREATE TABLE IF NOT EXISTS study_group_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES study_groups(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role VARCHAR(10) NOT NULL DEFAULT 'member' CHECK (role IN ('admin', 'member')),
+    joined_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (group_id, user_id)
+);
+
+-- Group study sets (shared study sets within a group)
+CREATE TABLE IF NOT EXISTS group_study_sets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES study_groups(id) ON DELETE CASCADE,
+    study_set_id UUID NOT NULL,
+    shared_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    shared_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (group_id, study_set_id)
+);
+
+-- Group activity feed
+CREATE TABLE IF NOT EXISTS group_activity (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES study_groups(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    action VARCHAR(50) NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_study_groups_invite_code ON study_groups(invite_code);
+CREATE INDEX IF NOT EXISTS idx_study_groups_created_by ON study_groups(created_by);
+CREATE INDEX IF NOT EXISTS idx_study_group_members_group_id ON study_group_members(group_id);
+CREATE INDEX IF NOT EXISTS idx_study_group_members_user_id ON study_group_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_group_study_sets_group_id ON group_study_sets(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_activity_group_id ON group_activity(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_activity_created_at ON group_activity(created_at DESC);

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { SubscriptionModule } from './modules/subscription';
 import { AnalyticsModule } from './modules/analytics';
 import { NotificationsModule } from './modules/notifications';
 import { BlogModule } from './modules/blog';
+import { StudyGroupsModule } from './modules/study-groups';
 
 // Common
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
@@ -97,6 +98,7 @@ import { HealthController } from './health.controller';
     AnalyticsModule,
     NotificationsModule,
     BlogModule,
+    StudyGroupsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/modules/study-groups/index.ts
+++ b/backend/src/modules/study-groups/index.ts
@@ -1,0 +1,3 @@
+export * from './study-groups.module';
+export * from './study-groups.service';
+export * from './study-groups.controller';

--- a/backend/src/modules/study-groups/study-groups.controller.ts
+++ b/backend/src/modules/study-groups/study-groups.controller.ts
@@ -1,0 +1,120 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, JwtPayload } from '../../common';
+import {
+  StudyGroupsService,
+  CreateStudyGroupDto,
+  ShareStudySetDto,
+} from './study-groups.service';
+
+@ApiTags('Study Groups')
+@Controller('study-groups')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class StudyGroupsController {
+  constructor(private readonly studyGroupsService: StudyGroupsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new study group' })
+  @ApiResponse({ status: 201, description: 'Study group created' })
+  async createGroup(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: CreateStudyGroupDto,
+  ) {
+    return this.studyGroupsService.createGroup(user.sub, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List my study groups' })
+  @ApiResponse({ status: 200, description: 'List of study groups' })
+  async listGroups(@CurrentUser() user: JwtPayload) {
+    return this.studyGroupsService.listGroups(user.sub);
+  }
+
+  @Post('join')
+  @ApiOperation({ summary: 'Join a study group via invite code' })
+  @ApiResponse({ status: 200, description: 'Joined study group' })
+  async joinGroup(
+    @CurrentUser() user: JwtPayload,
+    @Body('inviteCode') inviteCode: string,
+  ) {
+    return this.studyGroupsService.joinGroup(user.sub, inviteCode);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get study group details' })
+  @ApiResponse({ status: 200, description: 'Study group details' })
+  async getGroupDetails(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.studyGroupsService.getGroupDetails(user.sub, id);
+  }
+
+  @Get(':id/members')
+  @ApiOperation({ summary: 'Get study group members' })
+  @ApiResponse({ status: 200, description: 'List of group members' })
+  async getGroupMembers(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.studyGroupsService.getGroupMembers(user.sub, id);
+  }
+
+  @Post(':id/share')
+  @ApiOperation({ summary: 'Share a study set with the group' })
+  @ApiResponse({ status: 201, description: 'Study set shared' })
+  async shareStudySet(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: ShareStudySetDto,
+  ) {
+    return this.studyGroupsService.shareStudySet(user.sub, id, dto);
+  }
+
+  @Get(':id/study-sets')
+  @ApiOperation({ summary: 'Get study sets shared with the group' })
+  @ApiResponse({ status: 200, description: 'List of shared study sets' })
+  async getGroupStudySets(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.studyGroupsService.getGroupStudySets(user.sub, id);
+  }
+
+  @Get(':id/activity')
+  @ApiOperation({ summary: 'Get group activity feed' })
+  @ApiResponse({ status: 200, description: 'Activity feed' })
+  async getGroupActivity(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.studyGroupsService.getGroupActivity(user.sub, id);
+  }
+
+  @Delete(':id/leave')
+  @ApiOperation({ summary: 'Leave a study group' })
+  @ApiResponse({ status: 200, description: 'Left the group' })
+  async leaveGroup(
+    @CurrentUser() user: JwtPayload,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    await this.studyGroupsService.leaveGroup(user.sub, id);
+    return { message: 'Successfully left the group' };
+  }
+}

--- a/backend/src/modules/study-groups/study-groups.module.ts
+++ b/backend/src/modules/study-groups/study-groups.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StudyGroupsService } from './study-groups.service';
+import { StudyGroupsController } from './study-groups.controller';
+
+@Module({
+  controllers: [StudyGroupsController],
+  providers: [StudyGroupsService],
+  exports: [StudyGroupsService],
+})
+export class StudyGroupsModule {}

--- a/backend/src/modules/study-groups/study-groups.service.ts
+++ b/backend/src/modules/study-groups/study-groups.service.ts
@@ -1,0 +1,377 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { DatabaseService } from '../database/database.service';
+
+export interface CreateStudyGroupDto {
+  name: string;
+  description?: string;
+  isPrivate?: boolean;
+}
+
+export interface ShareStudySetDto {
+  studySetId: string;
+}
+
+export interface StudyGroup {
+  id: string;
+  name: string;
+  description: string | null;
+  inviteCode: string;
+  isPrivate: boolean;
+  createdBy: string;
+  createdAt: Date;
+  memberCount?: number;
+}
+
+export interface GroupMember {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  avatarUrl: string | null;
+  role: 'admin' | 'member';
+  joinedAt: Date;
+}
+
+export interface GroupStudySet {
+  id: string;
+  studySetId: string;
+  title: string;
+  description: string | null;
+  sharedBy: string;
+  sharedByName: string;
+  sharedAt: Date;
+}
+
+export interface GroupActivity {
+  id: string;
+  userId: string;
+  userName: string;
+  action: string;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+}
+
+@Injectable()
+export class StudyGroupsService {
+  private readonly logger = new Logger(StudyGroupsService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  private generateInviteCode(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let code = '';
+    for (let i = 0; i < 6; i++) {
+      code += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return code;
+  }
+
+  async createGroup(userId: string, dto: CreateStudyGroupDto): Promise<StudyGroup> {
+    if (!dto.name || dto.name.trim().length === 0) {
+      throw new BadRequestException('Group name is required');
+    }
+
+    const id = uuidv4();
+    let inviteCode = this.generateInviteCode();
+
+    // Ensure invite code is unique
+    let existing = await this.db.queryOne('SELECT id FROM study_groups WHERE invite_code = $1', [inviteCode]);
+    while (existing) {
+      inviteCode = this.generateInviteCode();
+      existing = await this.db.queryOne('SELECT id FROM study_groups WHERE invite_code = $1', [inviteCode]);
+    }
+
+    return this.db.transaction(async (client) => {
+      // Create the group
+      await client.query(
+        `INSERT INTO study_groups (id, name, description, invite_code, is_private, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [id, dto.name.trim(), dto.description?.trim() || null, inviteCode, dto.isPrivate ?? false, userId],
+      );
+
+      // Add creator as admin
+      await client.query(
+        `INSERT INTO study_group_members (id, group_id, user_id, role)
+         VALUES ($1, $2, $3, 'admin')`,
+        [uuidv4(), id, userId],
+      );
+
+      // Log activity
+      await client.query(
+        `INSERT INTO group_activity (id, group_id, user_id, action, metadata)
+         VALUES ($1, $2, $3, 'group_created', $4)`,
+        [uuidv4(), id, userId, JSON.stringify({ groupName: dto.name.trim() })],
+      );
+
+      return {
+        id,
+        name: dto.name.trim(),
+        description: dto.description?.trim() || null,
+        inviteCode,
+        isPrivate: dto.isPrivate ?? false,
+        createdBy: userId,
+        createdAt: new Date(),
+        memberCount: 1,
+      };
+    });
+  }
+
+  async joinGroup(userId: string, inviteCode: string): Promise<StudyGroup> {
+    const group = await this.db.queryOne<{
+      id: string;
+      name: string;
+      description: string | null;
+      invite_code: string;
+      is_private: boolean;
+      created_by: string;
+      created_at: Date;
+    }>('SELECT * FROM study_groups WHERE invite_code = $1', [inviteCode]);
+
+    if (!group) {
+      throw new NotFoundException('Invalid invite code');
+    }
+
+    // Check if already a member
+    const existingMember = await this.db.queryOne(
+      'SELECT id FROM study_group_members WHERE group_id = $1 AND user_id = $2',
+      [group.id, userId],
+    );
+
+    if (existingMember) {
+      throw new ConflictException('You are already a member of this group');
+    }
+
+    await this.db.query(
+      `INSERT INTO study_group_members (id, group_id, user_id, role)
+       VALUES ($1, $2, $3, 'member')`,
+      [uuidv4(), group.id, userId],
+    );
+
+    // Log activity
+    const user = await this.db.queryOne<{ name: string }>('SELECT name FROM users WHERE id = $1', [userId]);
+    await this.db.query(
+      `INSERT INTO group_activity (id, group_id, user_id, action, metadata)
+       VALUES ($1, $2, $3, 'member_joined', $4)`,
+      [uuidv4(), group.id, userId, JSON.stringify({ userName: user?.name || 'Unknown' })],
+    );
+
+    return {
+      id: group.id,
+      name: group.name,
+      description: group.description,
+      inviteCode: group.invite_code,
+      isPrivate: group.is_private,
+      createdBy: group.created_by,
+      createdAt: group.created_at,
+    };
+  }
+
+  async leaveGroup(userId: string, groupId: string): Promise<void> {
+    const member = await this.db.queryOne<{ role: string }>(
+      'SELECT role FROM study_group_members WHERE group_id = $1 AND user_id = $2',
+      [groupId, userId],
+    );
+
+    if (!member) {
+      throw new NotFoundException('You are not a member of this group');
+    }
+
+    // If the user is the last admin, prevent leaving
+    if (member.role === 'admin') {
+      const adminCount = await this.db.queryOne<{ count: string }>(
+        `SELECT COUNT(*) as count FROM study_group_members WHERE group_id = $1 AND role = 'admin'`,
+        [groupId],
+      );
+      if (parseInt(adminCount?.count || '0', 10) <= 1) {
+        const memberCount = await this.db.queryOne<{ count: string }>(
+          'SELECT COUNT(*) as count FROM study_group_members WHERE group_id = $1',
+          [groupId],
+        );
+        if (parseInt(memberCount?.count || '0', 10) > 1) {
+          throw new ForbiddenException(
+            'You are the last admin. Promote another member before leaving.',
+          );
+        }
+      }
+    }
+
+    await this.db.query(
+      'DELETE FROM study_group_members WHERE group_id = $1 AND user_id = $2',
+      [groupId, userId],
+    );
+
+    // If no members left, delete the group
+    const remaining = await this.db.queryOne<{ count: string }>(
+      'SELECT COUNT(*) as count FROM study_group_members WHERE group_id = $1',
+      [groupId],
+    );
+    if (parseInt(remaining?.count || '0', 10) === 0) {
+      await this.db.query('DELETE FROM study_groups WHERE id = $1', [groupId]);
+    }
+  }
+
+  async listGroups(userId: string): Promise<StudyGroup[]> {
+    const rows = await this.db.queryMany<{
+      id: string;
+      name: string;
+      description: string | null;
+      invite_code: string;
+      is_private: boolean;
+      created_by: string;
+      created_at: Date;
+      member_count: string;
+    }>(
+      `SELECT sg.*, COUNT(sgm.id) as member_count
+       FROM study_groups sg
+       JOIN study_group_members sgm ON sg.id = sgm.group_id
+       WHERE sg.id IN (SELECT group_id FROM study_group_members WHERE user_id = $1)
+       GROUP BY sg.id
+       ORDER BY sg.created_at DESC`,
+      [userId],
+    );
+
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      inviteCode: r.invite_code,
+      isPrivate: r.is_private,
+      createdBy: r.created_by,
+      createdAt: r.created_at,
+      memberCount: parseInt(r.member_count, 10),
+    }));
+  }
+
+  async getGroupDetails(userId: string, groupId: string): Promise<StudyGroup> {
+    // Verify membership
+    await this.verifyMembership(userId, groupId);
+
+    const row = await this.db.queryOne<{
+      id: string;
+      name: string;
+      description: string | null;
+      invite_code: string;
+      is_private: boolean;
+      created_by: string;
+      created_at: Date;
+      member_count: string;
+    }>(
+      `SELECT sg.*, COUNT(sgm.id) as member_count
+       FROM study_groups sg
+       JOIN study_group_members sgm ON sg.id = sgm.group_id
+       WHERE sg.id = $1
+       GROUP BY sg.id`,
+      [groupId],
+    );
+
+    if (!row) {
+      throw new NotFoundException('Group not found');
+    }
+
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      inviteCode: row.invite_code,
+      isPrivate: row.is_private,
+      createdBy: row.created_by,
+      createdAt: row.created_at,
+      memberCount: parseInt(row.member_count, 10),
+    };
+  }
+
+  async getGroupMembers(userId: string, groupId: string): Promise<GroupMember[]> {
+    await this.verifyMembership(userId, groupId);
+
+    return this.db.queryMany<GroupMember>(
+      `SELECT sgm.id, sgm.user_id as "userId", u.name, u.email,
+              u.avatar_url as "avatarUrl", sgm.role, sgm.joined_at as "joinedAt"
+       FROM study_group_members sgm
+       JOIN users u ON sgm.user_id = u.id
+       WHERE sgm.group_id = $1
+       ORDER BY sgm.role ASC, sgm.joined_at ASC`,
+      [groupId],
+    );
+  }
+
+  async shareStudySet(userId: string, groupId: string, dto: ShareStudySetDto): Promise<void> {
+    await this.verifyMembership(userId, groupId);
+
+    // Check if already shared
+    const existing = await this.db.queryOne(
+      'SELECT id FROM group_study_sets WHERE group_id = $1 AND study_set_id = $2',
+      [groupId, dto.studySetId],
+    );
+
+    if (existing) {
+      throw new ConflictException('This study set is already shared with the group');
+    }
+
+    await this.db.query(
+      `INSERT INTO group_study_sets (id, group_id, study_set_id, shared_by)
+       VALUES ($1, $2, $3, $4)`,
+      [uuidv4(), groupId, dto.studySetId, userId],
+    );
+
+    // Log activity
+    const user = await this.db.queryOne<{ name: string }>('SELECT name FROM users WHERE id = $1', [userId]);
+    await this.db.query(
+      `INSERT INTO group_activity (id, group_id, user_id, action, metadata)
+       VALUES ($1, $2, $3, 'study_set_shared', $4)`,
+      [uuidv4(), groupId, userId, JSON.stringify({ studySetId: dto.studySetId, userName: user?.name || 'Unknown' })],
+    );
+  }
+
+  async getGroupStudySets(userId: string, groupId: string): Promise<GroupStudySet[]> {
+    await this.verifyMembership(userId, groupId);
+
+    return this.db.queryMany<GroupStudySet>(
+      `SELECT gss.id, gss.study_set_id as "studySetId",
+              COALESCE(ss.title, 'Untitled') as title,
+              ss.description,
+              gss.shared_by as "sharedBy",
+              u.name as "sharedByName",
+              gss.shared_at as "sharedAt"
+       FROM group_study_sets gss
+       LEFT JOIN study_sets ss ON gss.study_set_id = ss.id
+       JOIN users u ON gss.shared_by = u.id
+       WHERE gss.group_id = $1
+       ORDER BY gss.shared_at DESC`,
+      [groupId],
+    );
+  }
+
+  async getGroupActivity(userId: string, groupId: string): Promise<GroupActivity[]> {
+    await this.verifyMembership(userId, groupId);
+
+    return this.db.queryMany<GroupActivity>(
+      `SELECT ga.id, ga.user_id as "userId", u.name as "userName",
+              ga.action, ga.metadata, ga.created_at as "createdAt"
+       FROM group_activity ga
+       JOIN users u ON ga.user_id = u.id
+       WHERE ga.group_id = $1
+       ORDER BY ga.created_at DESC
+       LIMIT 50`,
+      [groupId],
+    );
+  }
+
+  private async verifyMembership(userId: string, groupId: string): Promise<void> {
+    const member = await this.db.queryOne(
+      'SELECT id FROM study_group_members WHERE group_id = $1 AND user_id = $2',
+      [groupId, userId],
+    );
+
+    if (!member) {
+      throw new ForbiddenException('You are not a member of this group');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `study-groups` backend module with full CRUD: create group, join via 6-char invite code, leave, list members, share study sets, and activity feed
- Add database migration (`015_study_groups.sql`) creating `study_groups`, `study_group_members`, `group_study_sets`, and `group_activity` tables with proper FK constraints and indexes
- All endpoints are authenticated; membership is verified before accessing group resources

Closes #49

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/study-groups` | Create a group |
| GET | `/study-groups` | List my groups |
| POST | `/study-groups/join` | Join via invite code |
| GET | `/study-groups/:id` | Group details |
| GET | `/study-groups/:id/members` | List members |
| POST | `/study-groups/:id/share` | Share a study set |
| GET | `/study-groups/:id/study-sets` | Shared study sets |
| GET | `/study-groups/:id/activity` | Activity feed |
| DELETE | `/study-groups/:id/leave` | Leave group |

## Test plan
- [ ] Run `npx tsc --noEmit` in `backend/` -- 0 errors
- [ ] Run migration against a local database and verify tables are created
- [ ] Create a group, verify invite code is generated and creator is admin
- [ ] Join with invite code from a second user account
- [ ] Share a study set and confirm it appears in group study sets
- [ ] Verify activity feed captures join/share events
- [ ] Verify last-admin cannot leave if other members exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)