### PR TITLE
Add knowledge graph with entity extraction

### DIFF
--- a/backend/migrations/015_study_set_exam_dates.sql
+++ b/backend/migrations/015_study_set_exam_dates.sql
@@ -1,0 +1,14 @@
+-- Study Set Exam Dates table
+-- Allows students to set exam dates for study sets so the SRS can optimize review scheduling
+
+CREATE TABLE IF NOT EXISTS study_set_exam_dates (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    study_set_id UUID NOT NULL REFERENCES study_sets(id) ON DELETE CASCADE,
+    exam_date DATE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (user_id, study_set_id)
+);
+
+CREATE INDEX idx_study_set_exam_dates_user_id ON study_set_exam_dates(user_id);
+CREATE INDEX idx_study_set_exam_dates_exam_date ON study_set_exam_dates(exam_date);

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { SubscriptionModule } from './modules/subscription';
 import { AnalyticsModule } from './modules/analytics';
 import { NotificationsModule } from './modules/notifications';
 import { BlogModule } from './modules/blog';
+import { StudyPlannerModule } from './modules/study-planner';
 
 // Common
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
@@ -97,6 +98,7 @@ import { HealthController } from './health.controller';
     AnalyticsModule,
     NotificationsModule,
     BlogModule,
+    StudyPlannerModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -33,6 +33,7 @@ import { AnalyticsModule } from './modules/analytics';
 import { NotificationsModule } from './modules/notifications';
 import { BlogModule } from './modules/blog';
 import { StudyPlannerModule } from './modules/study-planner';
+import { KnowledgeGraphModule } from './modules/knowledge-graph';
 
 // Common
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
@@ -99,6 +100,7 @@ import { HealthController } from './health.controller';
     NotificationsModule,
     BlogModule,
     StudyPlannerModule,
+    KnowledgeGraphModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/modules/knowledge-graph/index.ts
+++ b/backend/src/modules/knowledge-graph/index.ts
@@ -1,0 +1,3 @@
+export * from './knowledge-graph.module';
+export * from './knowledge-graph.service';
+export * from './knowledge-graph.controller';

--- a/backend/src/modules/knowledge-graph/knowledge-graph.controller.ts
+++ b/backend/src/modules/knowledge-graph/knowledge-graph.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { KnowledgeGraphService, MergeGraphsDto } from './knowledge-graph.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, JwtPayload } from '../../common';
+
+@ApiTags('Knowledge Graph')
+@Controller('knowledge-graph')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class KnowledgeGraphController {
+  constructor(private readonly knowledgeGraphService: KnowledgeGraphService) {}
+
+  @Post(':studySetId/extract')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Extract entities and relationships from a study set' })
+  @ApiResponse({ status: 200, description: 'Entities extracted' })
+  async extract(@CurrentUser() user: JwtPayload, @Param('studySetId') studySetId: string) {
+    const entities = await this.knowledgeGraphService.extractEntities(user.sub, studySetId);
+    return { entitiesExtracted: entities.length, entities };
+  }
+
+  @Get(':studySetId')
+  @ApiOperation({ summary: 'Get knowledge graph for a study set' })
+  @ApiResponse({ status: 200, description: 'Knowledge graph data' })
+  async getGraph(@CurrentUser() user: JwtPayload, @Param('studySetId') studySetId: string) {
+    return this.knowledgeGraphService.getGraph(user.sub, studySetId);
+  }
+
+  @Get(':studySetId/entities')
+  @ApiOperation({ summary: 'List all entities for a study set' })
+  @ApiResponse({ status: 200, description: 'Entity list' })
+  async getEntities(@CurrentUser() user: JwtPayload, @Param('studySetId') studySetId: string) {
+    return this.knowledgeGraphService.getEntities(user.sub, studySetId);
+  }
+
+  @Get('entity/:id')
+  @ApiOperation({ summary: 'Get entity details with relationships' })
+  @ApiResponse({ status: 200, description: 'Entity detail' })
+  @ApiResponse({ status: 404, description: 'Entity not found' })
+  async getEntity(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
+    return this.knowledgeGraphService.getEntity(user.sub, id);
+  }
+
+  @Post('merge')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Merge knowledge graphs across multiple study sets' })
+  @ApiResponse({ status: 200, description: 'Merged graph' })
+  async mergeGraphs(@CurrentUser() user: JwtPayload, @Body() dto: MergeGraphsDto) {
+    return this.knowledgeGraphService.mergeGraphs(user.sub, dto.studySetIds);
+  }
+}

--- a/backend/src/modules/knowledge-graph/knowledge-graph.module.ts
+++ b/backend/src/modules/knowledge-graph/knowledge-graph.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { KnowledgeGraphService } from './knowledge-graph.service';
+import { KnowledgeGraphController } from './knowledge-graph.controller';
+
+@Module({
+  controllers: [KnowledgeGraphController],
+  providers: [KnowledgeGraphService],
+  exports: [KnowledgeGraphService],
+})
+export class KnowledgeGraphModule {}

--- a/backend/src/modules/knowledge-graph/knowledge-graph.service.ts
+++ b/backend/src/modules/knowledge-graph/knowledge-graph.service.ts
@@ -1,0 +1,590 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { DatabaseService } from '../database/database.service';
+import { AiService } from '../ai/ai.service';
+
+// ── Interfaces ──────────────────────────────────────────────
+
+export interface KnowledgeEntity {
+  id: string;
+  userId: string;
+  studySetId: string;
+  name: string;
+  entityType: string;
+  description: string;
+  sourceText: string | null;
+  createdAt: Date;
+}
+
+export interface KnowledgeRelationship {
+  id: string;
+  fromEntityId: string;
+  toEntityId: string;
+  relationshipType: string;
+  description: string;
+  createdAt: Date;
+}
+
+export interface GraphNode {
+  id: string;
+  name: string;
+  type: string;
+  description: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  label: string;
+  description: string;
+}
+
+export interface KnowledgeGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface ExtractEntitiesDto {
+  studySetId: string;
+}
+
+export interface MergeGraphsDto {
+  studySetIds: string[];
+}
+
+// ── Service ─────────────────────────────────────────────────
+
+@Injectable()
+export class KnowledgeGraphService {
+  private readonly logger = new Logger(KnowledgeGraphService.name);
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly aiService: AiService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS knowledge_entities (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          user_id UUID NOT NULL,
+          study_set_id UUID NOT NULL,
+          name VARCHAR(500) NOT NULL,
+          entity_type VARCHAR(50) NOT NULL,
+          description TEXT NOT NULL DEFAULT '',
+          source_text TEXT,
+          created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_knowledge_entities_user_study
+        ON knowledge_entities(user_id, study_set_id)
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_knowledge_entities_name
+        ON knowledge_entities(name)
+      `);
+
+      await this.db.query(`
+        CREATE TABLE IF NOT EXISTS knowledge_relationships (
+          id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+          from_entity_id UUID NOT NULL REFERENCES knowledge_entities(id) ON DELETE CASCADE,
+          to_entity_id UUID NOT NULL REFERENCES knowledge_entities(id) ON DELETE CASCADE,
+          relationship_type VARCHAR(100) NOT NULL,
+          description TEXT NOT NULL DEFAULT '',
+          created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_knowledge_relationships_from
+        ON knowledge_relationships(from_entity_id)
+      `);
+
+      await this.db.query(`
+        CREATE INDEX IF NOT EXISTS idx_knowledge_relationships_to
+        ON knowledge_relationships(to_entity_id)
+      `);
+
+      this.logger.log('Knowledge graph tables ready');
+    } catch (error) {
+      this.logger.warn(`Failed to ensure knowledge graph tables: ${(error as Error).message}`);
+    }
+  }
+
+  // ── Entity Extraction ───────────────────────────────────
+
+  async extractEntities(userId: string, studySetId: string): Promise<KnowledgeEntity[]> {
+    // Verify study set ownership
+    await this.verifyStudySetAccess(userId, studySetId);
+
+    // Gather text from the study set's content
+    const text = await this.gatherStudySetText(studySetId);
+    if (!text || text.trim().length === 0) {
+      throw new BadRequestException('Study set has no content to extract entities from');
+    }
+
+    // Prompt AI to extract entities
+    const response = await this.aiService.complete(
+      [
+        {
+          role: 'system',
+          content:
+            'You are an expert knowledge extraction assistant. You extract structured entities from educational content. Always respond with valid JSON only, no markdown fences.',
+        },
+        {
+          role: 'user',
+          content: `Extract all key concepts, people, dates, formulas, and definitions from the following study material. For each entity, provide: name, type (one of: concept, person, date, formula, definition, event), description (brief), and source_text (the exact excerpt it came from, max 200 chars).
+
+Return JSON in this exact format:
+{"entities":[{"name":"...","type":"...","description":"...","source_text":"..."}]}
+
+Study material:
+${text.substring(0, 12000)}`,
+        },
+      ],
+      {
+        temperature: 0.3,
+        maxTokens: 4096,
+        responseFormat: { type: 'json_object' },
+      },
+    );
+
+    let parsed: { entities: Array<{ name: string; type: string; description: string; source_text?: string }> };
+    try {
+      parsed = JSON.parse(response.content);
+    } catch {
+      this.logger.error('Failed to parse AI entity extraction response');
+      throw new BadRequestException('AI returned invalid JSON for entity extraction');
+    }
+
+    if (!parsed.entities || !Array.isArray(parsed.entities)) {
+      throw new BadRequestException('AI returned unexpected format for entity extraction');
+    }
+
+    // Clear previous entities for this study set (idempotent re-extraction)
+    await this.clearEntities(userId, studySetId);
+
+    // Store entities
+    const entities: KnowledgeEntity[] = [];
+    for (const raw of parsed.entities) {
+      const id = uuidv4();
+      const now = new Date();
+      await this.db.query(
+        `INSERT INTO knowledge_entities (id, user_id, study_set_id, name, entity_type, description, source_text, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [id, userId, studySetId, raw.name, raw.type, raw.description, raw.source_text || null, now],
+      );
+      entities.push({
+        id,
+        userId,
+        studySetId,
+        name: raw.name,
+        entityType: raw.type,
+        description: raw.description,
+        sourceText: raw.source_text || null,
+        createdAt: now,
+      });
+    }
+
+    this.logger.log(`Extracted ${entities.length} entities from study set ${studySetId}`);
+
+    // Automatically extract relationships after entities
+    await this.extractRelationships(userId, studySetId);
+
+    return entities;
+  }
+
+  // ── Relationship Extraction ─────────────────────────────
+
+  async extractRelationships(userId: string, studySetId: string): Promise<KnowledgeRelationship[]> {
+    await this.verifyStudySetAccess(userId, studySetId);
+
+    // Get existing entities for this study set
+    const entityRows = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT id, name, entity_type, description FROM knowledge_entities
+       WHERE user_id = $1 AND study_set_id = $2
+       ORDER BY name`,
+      [userId, studySetId],
+    );
+
+    if (entityRows.length < 2) {
+      this.logger.log('Not enough entities to extract relationships');
+      return [];
+    }
+
+    const entityList = entityRows
+      .map((e) => `- ${e.name} (${e.entity_type}): ${e.description}`)
+      .join('\n');
+
+    const response = await this.aiService.complete(
+      [
+        {
+          role: 'system',
+          content:
+            'You are an expert knowledge graph builder. You identify meaningful relationships between entities. Always respond with valid JSON only, no markdown fences.',
+        },
+        {
+          role: 'user',
+          content: `Given these entities from a study set, identify meaningful relationships between them.
+
+Entities:
+${entityList.substring(0, 8000)}
+
+Return JSON in this exact format:
+{"relationships":[{"from":"<entity name>","to":"<entity name>","relationship_type":"<type>","description":"<brief description>"}]}
+
+Where relationship_type is one of: relates_to, is_part_of, causes, precedes, depends_on, defines, contrasts_with, example_of, derived_from.`,
+        },
+      ],
+      {
+        temperature: 0.3,
+        maxTokens: 4096,
+        responseFormat: { type: 'json_object' },
+      },
+    );
+
+    let parsed: {
+      relationships: Array<{ from: string; to: string; relationship_type: string; description: string }>;
+    };
+    try {
+      parsed = JSON.parse(response.content);
+    } catch {
+      this.logger.error('Failed to parse AI relationship extraction response');
+      throw new BadRequestException('AI returned invalid JSON for relationship extraction');
+    }
+
+    if (!parsed.relationships || !Array.isArray(parsed.relationships)) {
+      return [];
+    }
+
+    // Build name-to-id lookup (case-insensitive)
+    const nameToId = new Map<string, string>();
+    for (const e of entityRows) {
+      nameToId.set((e.name as string).toLowerCase(), e.id as string);
+    }
+
+    // Clear previous relationships for this study set's entities
+    await this.clearRelationships(userId, studySetId);
+
+    const relationships: KnowledgeRelationship[] = [];
+    for (const raw of parsed.relationships) {
+      const fromId = nameToId.get(raw.from.toLowerCase());
+      const toId = nameToId.get(raw.to.toLowerCase());
+
+      if (!fromId || !toId || fromId === toId) {
+        continue; // Skip invalid or self-referential relationships
+      }
+
+      const id = uuidv4();
+      const now = new Date();
+      await this.db.query(
+        `INSERT INTO knowledge_relationships (id, from_entity_id, to_entity_id, relationship_type, description, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [id, fromId, toId, raw.relationship_type, raw.description, now],
+      );
+      relationships.push({
+        id,
+        fromEntityId: fromId,
+        toEntityId: toId,
+        relationshipType: raw.relationship_type,
+        description: raw.description,
+        createdAt: now,
+      });
+    }
+
+    this.logger.log(`Extracted ${relationships.length} relationships for study set ${studySetId}`);
+    return relationships;
+  }
+
+  // ── Graph Retrieval ─────────────────────────────────────
+
+  async getGraph(userId: string, studySetId: string): Promise<KnowledgeGraph> {
+    await this.verifyStudySetAccess(userId, studySetId);
+
+    const entityRows = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT id, name, entity_type, description FROM knowledge_entities
+       WHERE user_id = $1 AND study_set_id = $2
+       ORDER BY name`,
+      [userId, studySetId],
+    );
+
+    const entityIds = entityRows.map((e) => e.id as string);
+
+    let relationshipRows: Array<Record<string, unknown>> = [];
+    if (entityIds.length > 0) {
+      relationshipRows = await this.db.queryMany<Record<string, unknown>>(
+        `SELECT id, from_entity_id, to_entity_id, relationship_type, description
+         FROM knowledge_relationships
+         WHERE from_entity_id = ANY($1) OR to_entity_id = ANY($1)`,
+        [entityIds],
+      );
+    }
+
+    const nodes: GraphNode[] = entityRows.map((e) => ({
+      id: e.id as string,
+      name: e.name as string,
+      type: e.entity_type as string,
+      description: e.description as string,
+    }));
+
+    const edges: GraphEdge[] = relationshipRows.map((r) => ({
+      source: r.from_entity_id as string,
+      target: r.to_entity_id as string,
+      label: r.relationship_type as string,
+      description: r.description as string,
+    }));
+
+    return { nodes, edges };
+  }
+
+  // ── Entity Detail ───────────────────────────────────────
+
+  async getEntities(userId: string, studySetId: string): Promise<KnowledgeEntity[]> {
+    await this.verifyStudySetAccess(userId, studySetId);
+
+    const rows = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT * FROM knowledge_entities
+       WHERE user_id = $1 AND study_set_id = $2
+       ORDER BY name`,
+      [userId, studySetId],
+    );
+
+    return rows.map((r) => this.mapEntity(r));
+  }
+
+  async getEntity(userId: string, entityId: string): Promise<{
+    entity: KnowledgeEntity;
+    relationships: Array<{
+      id: string;
+      relatedEntity: GraphNode;
+      relationshipType: string;
+      description: string;
+      direction: 'outgoing' | 'incoming';
+    }>;
+  }> {
+    const row = await this.db.queryOne<Record<string, unknown>>(
+      `SELECT * FROM knowledge_entities WHERE id = $1`,
+      [entityId],
+    );
+
+    if (!row) {
+      throw new NotFoundException('Entity not found');
+    }
+
+    if ((row.user_id as string) !== userId) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    const entity = this.mapEntity(row);
+
+    // Get all relationships involving this entity
+    const relRows = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT r.id, r.from_entity_id, r.to_entity_id, r.relationship_type, r.description,
+              e.id AS related_id, e.name AS related_name, e.entity_type AS related_type, e.description AS related_description
+       FROM knowledge_relationships r
+       JOIN knowledge_entities e
+         ON (e.id = CASE WHEN r.from_entity_id = $1 THEN r.to_entity_id ELSE r.from_entity_id END)
+       WHERE r.from_entity_id = $1 OR r.to_entity_id = $1`,
+      [entityId],
+    );
+
+    const relationships = relRows.map((r) => ({
+      id: r.id as string,
+      relatedEntity: {
+        id: r.related_id as string,
+        name: r.related_name as string,
+        type: r.related_type as string,
+        description: r.related_description as string,
+      },
+      relationshipType: r.relationship_type as string,
+      description: r.description as string,
+      direction: ((r.from_entity_id as string) === entityId ? 'outgoing' : 'incoming') as 'outgoing' | 'incoming',
+    }));
+
+    return { entity, relationships };
+  }
+
+  // ── Merge Graphs ────────────────────────────────────────
+
+  async mergeGraphs(userId: string, studySetIds: string[]): Promise<KnowledgeGraph> {
+    if (!studySetIds || studySetIds.length < 2) {
+      throw new BadRequestException('At least two study set IDs are required for merging');
+    }
+
+    // Verify access to all study sets
+    for (const id of studySetIds) {
+      await this.verifyStudySetAccess(userId, id);
+    }
+
+    // Get all entities across the study sets
+    const entityRows = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT * FROM knowledge_entities
+       WHERE user_id = $1 AND study_set_id = ANY($2)
+       ORDER BY name`,
+      [userId, studySetIds],
+    );
+
+    // Merge entities with same name (case-insensitive)
+    const mergedMap = new Map<string, GraphNode>();
+    const idRemapping = new Map<string, string>(); // old id -> canonical id
+
+    for (const row of entityRows) {
+      const key = (row.name as string).toLowerCase();
+      const entityId = row.id as string;
+
+      if (mergedMap.has(key)) {
+        // Map this duplicate to the canonical entity
+        const canonical = mergedMap.get(key)!;
+        idRemapping.set(entityId, canonical.id);
+      } else {
+        const node: GraphNode = {
+          id: entityId,
+          name: row.name as string,
+          type: row.entity_type as string,
+          description: row.description as string,
+        };
+        mergedMap.set(key, node);
+        idRemapping.set(entityId, entityId);
+      }
+    }
+
+    const nodes = Array.from(mergedMap.values());
+
+    // Get all relationships
+    const allEntityIds = entityRows.map((e) => e.id as string);
+    let relationshipRows: Array<Record<string, unknown>> = [];
+    if (allEntityIds.length > 0) {
+      relationshipRows = await this.db.queryMany<Record<string, unknown>>(
+        `SELECT * FROM knowledge_relationships
+         WHERE from_entity_id = ANY($1) OR to_entity_id = ANY($1)`,
+        [allEntityIds],
+      );
+    }
+
+    // Deduplicate edges after remapping
+    const edgeSet = new Set<string>();
+    const edges: GraphEdge[] = [];
+
+    for (const r of relationshipRows) {
+      const source = idRemapping.get(r.from_entity_id as string) || (r.from_entity_id as string);
+      const target = idRemapping.get(r.to_entity_id as string) || (r.to_entity_id as string);
+      const label = r.relationship_type as string;
+      const edgeKey = `${source}|${target}|${label}`;
+
+      if (source === target || edgeSet.has(edgeKey)) {
+        continue;
+      }
+
+      edgeSet.add(edgeKey);
+      edges.push({
+        source,
+        target,
+        label,
+        description: r.description as string,
+      });
+    }
+
+    this.logger.log(
+      `Merged graph: ${nodes.length} nodes, ${edges.length} edges across ${studySetIds.length} study sets`,
+    );
+
+    return { nodes, edges };
+  }
+
+  // ── Private Helpers ─────────────────────────────────────
+
+  private async verifyStudySetAccess(userId: string, studySetId: string): Promise<void> {
+    const studySet = await this.db.queryOne<Record<string, unknown>>(
+      `SELECT id, user_id FROM study_sets WHERE id = $1`,
+      [studySetId],
+    );
+
+    if (!studySet) {
+      throw new NotFoundException('Study set not found');
+    }
+
+    if ((studySet.user_id as string) !== userId) {
+      throw new ForbiddenException('Access denied to this study set');
+    }
+  }
+
+  private async gatherStudySetText(studySetId: string): Promise<string> {
+    // Gather text from flashcards
+    const flashcards = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT front, back FROM flashcards WHERE study_set_id = $1 ORDER BY position`,
+      [studySetId],
+    );
+
+    // Gather text from study set notes / description
+    const studySet = await this.db.queryOne<Record<string, unknown>>(
+      `SELECT name, description FROM study_sets WHERE id = $1`,
+      [studySetId],
+    );
+
+    const parts: string[] = [];
+
+    if (studySet) {
+      if (studySet.name) parts.push(`Title: ${studySet.name}`);
+      if (studySet.description) parts.push(`Description: ${studySet.description}`);
+    }
+
+    for (const card of flashcards) {
+      if (card.front) parts.push(`Q: ${card.front}`);
+      if (card.back) parts.push(`A: ${card.back}`);
+    }
+
+    // Also try documents/notes linked to study set
+    const notes = await this.db.queryMany<Record<string, unknown>>(
+      `SELECT content FROM study_notes WHERE study_set_id = $1`,
+      [studySetId],
+    );
+
+    for (const note of notes) {
+      if (note.content) parts.push(note.content as string);
+    }
+
+    return parts.join('\n\n');
+  }
+
+  private async clearEntities(userId: string, studySetId: string): Promise<void> {
+    // First clear relationships that reference these entities
+    await this.clearRelationships(userId, studySetId);
+
+    await this.db.query(
+      `DELETE FROM knowledge_entities WHERE user_id = $1 AND study_set_id = $2`,
+      [userId, studySetId],
+    );
+  }
+
+  private async clearRelationships(userId: string, studySetId: string): Promise<void> {
+    await this.db.query(
+      `DELETE FROM knowledge_relationships
+       WHERE from_entity_id IN (SELECT id FROM knowledge_entities WHERE user_id = $1 AND study_set_id = $2)
+          OR to_entity_id IN (SELECT id FROM knowledge_entities WHERE user_id = $1 AND study_set_id = $2)`,
+      [userId, studySetId, userId, studySetId],
+    );
+  }
+
+  private mapEntity(row: Record<string, unknown>): KnowledgeEntity {
+    return {
+      id: row.id as string,
+      userId: row.user_id as string,
+      studySetId: row.study_set_id as string,
+      name: row.name as string,
+      entityType: row.entity_type as string,
+      description: row.description as string,
+      sourceText: (row.source_text as string) || null,
+      createdAt: new Date(row.created_at as string),
+    };
+  }
+}

--- a/backend/src/modules/study-planner/index.ts
+++ b/backend/src/modules/study-planner/index.ts
@@ -1,0 +1,3 @@
+export * from './study-planner.module';
+export * from './study-planner.service';
+export * from './study-planner.controller';

--- a/backend/src/modules/study-planner/study-planner.controller.ts
+++ b/backend/src/modules/study-planner/study-planner.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  UseGuards,
+  Header,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, JwtPayload } from '../../common';
+import { StudyPlannerService } from './study-planner.service';
+
+@ApiTags('Study Planner')
+@Controller('study-planner')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class StudyPlannerController {
+  constructor(private readonly studyPlannerService: StudyPlannerService) {}
+
+  @Get('upcoming')
+  @ApiOperation({ summary: 'Get upcoming flashcard reviews' })
+  @ApiQuery({ name: 'days', required: false, type: Number, description: 'Number of days to look ahead (default 14)' })
+  @ApiResponse({ status: 200, description: 'Upcoming reviews grouped by date' })
+  async getUpcomingReviews(
+    @CurrentUser() user: JwtPayload,
+    @Query('days') days?: string,
+  ) {
+    const numDays = days ? parseInt(days, 10) : 14;
+    return this.studyPlannerService.getUpcomingReviews(user.sub, numDays);
+  }
+
+  @Get('daily')
+  @ApiOperation({ summary: 'Get daily study plan' })
+  @ApiQuery({ name: 'date', required: false, type: String, description: 'Date in YYYY-MM-DD format (default today)' })
+  @ApiResponse({ status: 200, description: 'Daily study plan with prioritized items' })
+  async getDailyPlan(
+    @CurrentUser() user: JwtPayload,
+    @Query('date') date?: string,
+  ) {
+    const planDate = date || new Date().toISOString().split('T')[0];
+    return this.studyPlannerService.getDailyPlan(user.sub, planDate);
+  }
+
+  @Post('exam-date')
+  @ApiOperation({ summary: 'Set an exam date for a study set' })
+  @ApiResponse({ status: 201, description: 'Exam date set' })
+  async setExamDate(
+    @CurrentUser() user: JwtPayload,
+    @Body() body: { studySetId: string; examDate: string },
+  ) {
+    return this.studyPlannerService.setExamDate(
+      user.sub,
+      body.studySetId,
+      body.examDate,
+    );
+  }
+
+  @Get('streak')
+  @ApiOperation({ summary: 'Get study streak and heatmap data' })
+  @ApiResponse({ status: 200, description: 'Current streak, longest streak, and 90-day heatmap' })
+  async getStudyStreak(@CurrentUser() user: JwtPayload) {
+    return this.studyPlannerService.getStudyStreak(user.sub);
+  }
+
+  @Get('export/ical')
+  @ApiOperation({ summary: 'Export study schedule as iCal file' })
+  @ApiResponse({ status: 200, description: 'iCal file content' })
+  @Header('Content-Type', 'text/calendar; charset=utf-8')
+  @Header('Content-Disposition', 'attachment; filename="studyield-schedule.ics"')
+  async exportIcal(@CurrentUser() user: JwtPayload) {
+    return this.studyPlannerService.exportToIcal(user.sub);
+  }
+}

--- a/backend/src/modules/study-planner/study-planner.module.ts
+++ b/backend/src/modules/study-planner/study-planner.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { StudyPlannerService } from './study-planner.service';
+import { StudyPlannerController } from './study-planner.controller';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [StudyPlannerController],
+  providers: [StudyPlannerService],
+  exports: [StudyPlannerService],
+})
+export class StudyPlannerModule {}

--- a/backend/src/modules/study-planner/study-planner.service.ts
+++ b/backend/src/modules/study-planner/study-planner.service.ts
@@ -1,0 +1,380 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+
+export interface UpcomingReviewDay {
+  date: string;
+  reviewCount: number;
+  studySets: Array<{ id: string; name: string; dueCount: number }>;
+}
+
+export interface DailyPlanItem {
+  type: 'review' | 'quiz_deadline' | 'exam';
+  priority: number;
+  studySetId: string;
+  studySetName: string;
+  detail: string;
+  count?: number;
+  examDate?: string;
+}
+
+export interface StudyStreakData {
+  currentStreak: number;
+  longestStreak: number;
+  heatmap: Array<{ date: string; count: number }>;
+}
+
+export interface ExamDateRecord {
+  id: string;
+  userId: string;
+  studySetId: string;
+  examDate: string;
+  createdAt: Date;
+}
+
+@Injectable()
+export class StudyPlannerService {
+  private readonly logger = new Logger(StudyPlannerService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Get upcoming flashcard reviews for the next N days, grouped by date
+   */
+  async getUpcomingReviews(userId: string, days: number): Promise<UpcomingReviewDay[]> {
+    const result = await this.db.queryMany<{
+      review_date: string;
+      review_count: string;
+      study_set_id: string;
+      study_set_name: string;
+      due_count: string;
+    }>(
+      `SELECT
+        DATE(f.next_review_at) AS review_date,
+        COUNT(f.id) AS review_count,
+        s.id AS study_set_id,
+        s.title AS study_set_name,
+        COUNT(f.id) AS due_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND f.next_review_at >= NOW()
+        AND f.next_review_at < NOW() + ($2 || ' days')::INTERVAL
+      GROUP BY DATE(f.next_review_at), s.id, s.title
+      ORDER BY review_date ASC`,
+      [userId, days.toString()],
+    );
+
+    // Group by date
+    const byDate = new Map<string, UpcomingReviewDay>();
+    for (const row of result) {
+      const dateStr = row.review_date;
+      if (!byDate.has(dateStr)) {
+        byDate.set(dateStr, { date: dateStr, reviewCount: 0, studySets: [] });
+      }
+      const day = byDate.get(dateStr)!;
+      const dueCount = parseInt(row.due_count, 10);
+      day.reviewCount += dueCount;
+      day.studySets.push({
+        id: row.study_set_id,
+        name: row.study_set_name,
+        dueCount,
+      });
+    }
+
+    return Array.from(byDate.values());
+  }
+
+  /**
+   * Get the daily study plan for a specific date
+   * Prioritized: overdue first, then due today, then upcoming
+   */
+  async getDailyPlan(userId: string, date: string): Promise<DailyPlanItem[]> {
+    const items: DailyPlanItem[] = [];
+
+    // 1. Overdue flashcard reviews (before today)
+    const overdueReviews = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      overdue_count: string;
+    }>(
+      `SELECT
+        s.id AS study_set_id,
+        s.title AS study_set_name,
+        COUNT(f.id) AS overdue_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND f.next_review_at < $2::DATE
+        AND f.next_review_at IS NOT NULL
+      GROUP BY s.id, s.title
+      ORDER BY overdue_count DESC`,
+      [userId, date],
+    );
+
+    for (const row of overdueReviews) {
+      items.push({
+        type: 'review',
+        priority: 1,
+        studySetId: row.study_set_id,
+        studySetName: row.study_set_name,
+        detail: `${row.overdue_count} overdue review(s)`,
+        count: parseInt(row.overdue_count, 10),
+      });
+    }
+
+    // 2. Due today flashcard reviews
+    const todayReviews = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      due_count: string;
+    }>(
+      `SELECT
+        s.id AS study_set_id,
+        s.title AS study_set_name,
+        COUNT(f.id) AS due_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND DATE(f.next_review_at) = $2::DATE
+      GROUP BY s.id, s.title
+      ORDER BY due_count DESC`,
+      [userId, date],
+    );
+
+    for (const row of todayReviews) {
+      items.push({
+        type: 'review',
+        priority: 2,
+        studySetId: row.study_set_id,
+        studySetName: row.study_set_name,
+        detail: `${row.due_count} review(s) due today`,
+        count: parseInt(row.due_count, 10),
+      });
+    }
+
+    // 3. Exam dates for the given date
+    const exams = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      exam_date: string;
+    }>(
+      `SELECT
+        e.study_set_id,
+        s.title AS study_set_name,
+        e.exam_date::TEXT
+      FROM study_set_exam_dates e
+      JOIN study_sets s ON e.study_set_id = s.id
+      WHERE e.user_id = $1
+        AND e.exam_date = $2::DATE`,
+      [userId, date],
+    );
+
+    for (const row of exams) {
+      items.push({
+        type: 'exam',
+        priority: 0,
+        studySetId: row.study_set_id,
+        studySetName: row.study_set_name,
+        detail: `Exam scheduled`,
+        examDate: row.exam_date,
+      });
+    }
+
+    // Sort by priority (lower number = higher priority)
+    items.sort((a, b) => a.priority - b.priority);
+
+    return items;
+  }
+
+  /**
+   * Set an exam date for a study set
+   */
+  async setExamDate(
+    userId: string,
+    studySetId: string,
+    examDate: string,
+  ): Promise<ExamDateRecord> {
+    // Upsert: if exam date already exists for this user+study_set, update it
+    const result = await this.db.queryOne<{
+      id: string;
+      user_id: string;
+      study_set_id: string;
+      exam_date: string;
+      created_at: Date;
+    }>(
+      `INSERT INTO study_set_exam_dates (user_id, study_set_id, exam_date)
+      VALUES ($1, $2, $3::DATE)
+      ON CONFLICT (user_id, study_set_id)
+      DO UPDATE SET exam_date = $3::DATE
+      RETURNING id, user_id, study_set_id, exam_date::TEXT, created_at`,
+      [userId, studySetId, examDate],
+    );
+
+    if (!result) {
+      throw new Error('Failed to set exam date');
+    }
+
+    return {
+      id: result.id,
+      userId: result.user_id,
+      studySetId: result.study_set_id,
+      examDate: result.exam_date,
+      createdAt: result.created_at,
+    };
+  }
+
+  /**
+   * Get study streak and calendar heatmap data for the last 90 days
+   */
+  async getStudyStreak(userId: string): Promise<StudyStreakData> {
+    // Get flashcard review activity per day for the last 90 days
+    const activity = await this.db.queryMany<{
+      activity_date: string;
+      review_count: string;
+    }>(
+      `SELECT
+        DATE(f.last_reviewed_at) AS activity_date,
+        COUNT(f.id) AS review_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND f.last_reviewed_at >= NOW() - INTERVAL '90 days'
+        AND f.last_reviewed_at IS NOT NULL
+      GROUP BY DATE(f.last_reviewed_at)
+      ORDER BY activity_date ASC`,
+      [userId],
+    );
+
+    const heatmap = activity.map((a) => ({
+      date: a.activity_date,
+      count: parseInt(a.review_count, 10),
+    }));
+
+    // Calculate streaks
+    const { current, longest } = this.calculateStreak(heatmap);
+
+    return {
+      currentStreak: current,
+      longestStreak: longest,
+      heatmap,
+    };
+  }
+
+  /**
+   * Export upcoming reviews and exam dates as iCal (.ics) file
+   */
+  async exportToIcal(userId: string): Promise<string> {
+    // Get upcoming reviews for the next 30 days
+    const upcoming = await this.getUpcomingReviews(userId, 30);
+
+    // Get all exam dates
+    const exams = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      exam_date: string;
+    }>(
+      `SELECT
+        e.study_set_id,
+        s.title AS study_set_name,
+        e.exam_date::TEXT
+      FROM study_set_exam_dates e
+      JOIN study_sets s ON e.study_set_id = s.id
+      WHERE e.user_id = $1
+        AND e.exam_date >= CURRENT_DATE`,
+      [userId],
+    );
+
+    const lines: string[] = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Studyield//Study Planner//EN',
+      'CALSCALE:GREGORIAN',
+      'METHOD:PUBLISH',
+    ];
+
+    // Add review sessions
+    for (const day of upcoming) {
+      const dateCompact = day.date.replace(/-/g, '');
+      const setNames = day.studySets.map((s) => s.name).join(', ');
+      lines.push('BEGIN:VEVENT');
+      lines.push(`DTSTART;VALUE=DATE:${dateCompact}`);
+      lines.push(`DTEND;VALUE=DATE:${dateCompact}`);
+      lines.push(`SUMMARY:${day.reviewCount} flashcard review(s) due`);
+      lines.push(`DESCRIPTION:Study sets: ${this.escapeIcal(setNames)}`);
+      lines.push(`UID:review-${dateCompact}-${userId}@studyield`);
+      lines.push('END:VEVENT');
+    }
+
+    // Add exam dates
+    for (const exam of exams) {
+      const dateCompact = exam.exam_date.replace(/-/g, '');
+      lines.push('BEGIN:VEVENT');
+      lines.push(`DTSTART;VALUE=DATE:${dateCompact}`);
+      lines.push(`DTEND;VALUE=DATE:${dateCompact}`);
+      lines.push(`SUMMARY:Exam: ${this.escapeIcal(exam.study_set_name)}`);
+      lines.push(`DESCRIPTION:Exam for study set: ${this.escapeIcal(exam.study_set_name)}`);
+      lines.push(`UID:exam-${exam.study_set_id}-${dateCompact}@studyield`);
+      lines.push('END:VEVENT');
+    }
+
+    lines.push('END:VCALENDAR');
+
+    return lines.join('\r\n');
+  }
+
+  private escapeIcal(text: string): string {
+    return text
+      .replace(/\\/g, '\\\\')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+      .replace(/\n/g, '\\n');
+  }
+
+  private calculateStreak(
+    activity: Array<{ date: string; count: number }>,
+  ): { current: number; longest: number } {
+    if (activity.length === 0) return { current: 0, longest: 0 };
+
+    let current = 0;
+    let longest = 0;
+    let streak = 0;
+    let lastDate: Date | null = null;
+
+    const sorted = [...activity].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+
+    for (const a of sorted) {
+      if (a.count === 0) continue;
+      const date = new Date(a.date);
+      if (lastDate) {
+        const diff = Math.floor(
+          (date.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        if (diff === 1) {
+          streak++;
+        } else {
+          longest = Math.max(longest, streak);
+          streak = 1;
+        }
+      } else {
+        streak = 1;
+      }
+      lastDate = date;
+    }
+
+    longest = Math.max(longest, streak);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (lastDate) {
+      lastDate.setHours(0, 0, 0, 0);
+      const diff = Math.floor(
+        (today.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      current = diff <= 1 ? streak : 0;
+    }
+
+    return { current, longest };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `knowledge-graph` module with AI-powered entity extraction from study set content (flashcards, notes, descriptions)
- Extracts named entities (concepts, people, dates, formulas, definitions, events) and maps relationships between them
- Supports cross-study-set graph merging with automatic entity deduplication
- Auto-creates `knowledge_entities` and `knowledge_relationships` tables on startup

## Endpoints
- `POST /knowledge-graph/:studySetId/extract` — trigger extraction
- `GET /knowledge-graph/:studySetId` — get graph (nodes + edges)
- `GET /knowledge-graph/:studySetId/entities` — list entities
- `GET /knowledge-graph/entity/:id` — entity detail with relationships
- `POST /knowledge-graph/merge` — merge graphs across study sets

## Test plan
- [ ] Verify `tsc --noEmit` passes with 0 errors
- [ ] Create a study set with flashcards, trigger extraction, verify entities are returned
- [ ] Verify relationships are extracted between entities
- [ ] Verify `GET /knowledge-graph/:id` returns correct nodes and edges
- [ ] Test merge endpoint with two study sets sharing common entities
- [ ] Verify ownership checks prevent cross-user access

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)