### PR TITLE
feat: study planner with SRS schedule visualization

### DIFF
--- a/backend/migrations/015_study_set_exam_dates.sql
+++ b/backend/migrations/015_study_set_exam_dates.sql
@@ -1,0 +1,14 @@
+-- Study Set Exam Dates table
+-- Allows students to set exam dates for study sets so the SRS can optimize review scheduling
+
+CREATE TABLE IF NOT EXISTS study_set_exam_dates (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    study_set_id UUID NOT NULL REFERENCES study_sets(id) ON DELETE CASCADE,
+    exam_date DATE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE (user_id, study_set_id)
+);
+
+CREATE INDEX idx_study_set_exam_dates_user_id ON study_set_exam_dates(user_id);
+CREATE INDEX idx_study_set_exam_dates_exam_date ON study_set_exam_dates(exam_date);

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { SubscriptionModule } from './modules/subscription';
 import { AnalyticsModule } from './modules/analytics';
 import { NotificationsModule } from './modules/notifications';
 import { BlogModule } from './modules/blog';
+import { StudyPlannerModule } from './modules/study-planner';
 
 // Common
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
@@ -97,6 +98,7 @@ import { HealthController } from './health.controller';
     AnalyticsModule,
     NotificationsModule,
     BlogModule,
+    StudyPlannerModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/modules/study-planner/index.ts
+++ b/backend/src/modules/study-planner/index.ts
@@ -1,0 +1,3 @@
+export * from './study-planner.module';
+export * from './study-planner.service';
+export * from './study-planner.controller';

--- a/backend/src/modules/study-planner/study-planner.controller.ts
+++ b/backend/src/modules/study-planner/study-planner.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  UseGuards,
+  Header,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser, JwtPayload } from '../../common';
+import { StudyPlannerService } from './study-planner.service';
+
+@ApiTags('Study Planner')
+@Controller('study-planner')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class StudyPlannerController {
+  constructor(private readonly studyPlannerService: StudyPlannerService) {}
+
+  @Get('upcoming')
+  @ApiOperation({ summary: 'Get upcoming flashcard reviews' })
+  @ApiQuery({ name: 'days', required: false, type: Number, description: 'Number of days to look ahead (default 14)' })
+  @ApiResponse({ status: 200, description: 'Upcoming reviews grouped by date' })
+  async getUpcomingReviews(
+    @CurrentUser() user: JwtPayload,
+    @Query('days') days?: string,
+  ) {
+    const numDays = days ? parseInt(days, 10) : 14;
+    return this.studyPlannerService.getUpcomingReviews(user.sub, numDays);
+  }
+
+  @Get('daily')
+  @ApiOperation({ summary: 'Get daily study plan' })
+  @ApiQuery({ name: 'date', required: false, type: String, description: 'Date in YYYY-MM-DD format (default today)' })
+  @ApiResponse({ status: 200, description: 'Daily study plan with prioritized items' })
+  async getDailyPlan(
+    @CurrentUser() user: JwtPayload,
+    @Query('date') date?: string,
+  ) {
+    const planDate = date || new Date().toISOString().split('T')[0];
+    return this.studyPlannerService.getDailyPlan(user.sub, planDate);
+  }
+
+  @Post('exam-date')
+  @ApiOperation({ summary: 'Set an exam date for a study set' })
+  @ApiResponse({ status: 201, description: 'Exam date set' })
+  async setExamDate(
+    @CurrentUser() user: JwtPayload,
+    @Body() body: { studySetId: string; examDate: string },
+  ) {
+    return this.studyPlannerService.setExamDate(
+      user.sub,
+      body.studySetId,
+      body.examDate,
+    );
+  }
+
+  @Get('streak')
+  @ApiOperation({ summary: 'Get study streak and heatmap data' })
+  @ApiResponse({ status: 200, description: 'Current streak, longest streak, and 90-day heatmap' })
+  async getStudyStreak(@CurrentUser() user: JwtPayload) {
+    return this.studyPlannerService.getStudyStreak(user.sub);
+  }
+
+  @Get('export/ical')
+  @ApiOperation({ summary: 'Export study schedule as iCal file' })
+  @ApiResponse({ status: 200, description: 'iCal file content' })
+  @Header('Content-Type', 'text/calendar; charset=utf-8')
+  @Header('Content-Disposition', 'attachment; filename="studyield-schedule.ics"')
+  async exportIcal(@CurrentUser() user: JwtPayload) {
+    return this.studyPlannerService.exportToIcal(user.sub);
+  }
+}

--- a/backend/src/modules/study-planner/study-planner.module.ts
+++ b/backend/src/modules/study-planner/study-planner.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { StudyPlannerService } from './study-planner.service';
+import { StudyPlannerController } from './study-planner.controller';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [StudyPlannerController],
+  providers: [StudyPlannerService],
+  exports: [StudyPlannerService],
+})
+export class StudyPlannerModule {}

--- a/backend/src/modules/study-planner/study-planner.service.ts
+++ b/backend/src/modules/study-planner/study-planner.service.ts
@@ -1,0 +1,380 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+
+export interface UpcomingReviewDay {
+  date: string;
+  reviewCount: number;
+  studySets: Array<{ id: string; name: string; dueCount: number }>;
+}
+
+export interface DailyPlanItem {
+  type: 'review' | 'quiz_deadline' | 'exam';
+  priority: number;
+  studySetId: string;
+  studySetName: string;
+  detail: string;
+  count?: number;
+  examDate?: string;
+}
+
+export interface StudyStreakData {
+  currentStreak: number;
+  longestStreak: number;
+  heatmap: Array<{ date: string; count: number }>;
+}
+
+export interface ExamDateRecord {
+  id: string;
+  userId: string;
+  studySetId: string;
+  examDate: string;
+  createdAt: Date;
+}
+
+@Injectable()
+export class StudyPlannerService {
+  private readonly logger = new Logger(StudyPlannerService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  /**
+   * Get upcoming flashcard reviews for the next N days, grouped by date
+   */
+  async getUpcomingReviews(userId: string, days: number): Promise<UpcomingReviewDay[]> {
+    const result = await this.db.queryMany<{
+      review_date: string;
+      review_count: string;
+      study_set_id: string;
+      study_set_name: string;
+      due_count: string;
+    }>(
+      `SELECT
+        DATE(f.next_review_at) AS review_date,
+        COUNT(f.id) AS review_count,
+        s.id AS study_set_id,
+        s.title AS study_set_name,
+        COUNT(f.id) AS due_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND f.next_review_at >= NOW()
+        AND f.next_review_at < NOW() + ($2 || ' days')::INTERVAL
+      GROUP BY DATE(f.next_review_at), s.id, s.title
+      ORDER BY review_date ASC`,
+      [userId, days.toString()],
+    );
+
+    // Group by date
+    const byDate = new Map<string, UpcomingReviewDay>();
+    for (const row of result) {
+      const dateStr = row.review_date;
+      if (!byDate.has(dateStr)) {
+        byDate.set(dateStr, { date: dateStr, reviewCount: 0, studySets: [] });
+      }
+      const day = byDate.get(dateStr)!;
+      const dueCount = parseInt(row.due_count, 10);
+      day.reviewCount += dueCount;
+      day.studySets.push({
+        id: row.study_set_id,
+        name: row.study_set_name,
+        dueCount,
+      });
+    }
+
+    return Array.from(byDate.values());
+  }
+
+  /**
+   * Get the daily study plan for a specific date
+   * Prioritized: overdue first, then due today, then upcoming
+   */
+  async getDailyPlan(userId: string, date: string): Promise<DailyPlanItem[]> {
+    const items: DailyPlanItem[] = [];
+
+    // 1. Overdue flashcard reviews (before today)
+    const overdueReviews = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      overdue_count: string;
+    }>(
+      `SELECT
+        s.id AS study_set_id,
+        s.title AS study_set_name,
+        COUNT(f.id) AS overdue_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND f.next_review_at < $2::DATE
+        AND f.next_review_at IS NOT NULL
+      GROUP BY s.id, s.title
+      ORDER BY overdue_count DESC`,
+      [userId, date],
+    );
+
+    for (const row of overdueReviews) {
+      items.push({
+        type: 'review',
+        priority: 1,
+        studySetId: row.study_set_id,
+        studySetName: row.study_set_name,
+        detail: `${row.overdue_count} overdue review(s)`,
+        count: parseInt(row.overdue_count, 10),
+      });
+    }
+
+    // 2. Due today flashcard reviews
+    const todayReviews = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      due_count: string;
+    }>(
+      `SELECT
+        s.id AS study_set_id,
+        s.title AS study_set_name,
+        COUNT(f.id) AS due_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND DATE(f.next_review_at) = $2::DATE
+      GROUP BY s.id, s.title
+      ORDER BY due_count DESC`,
+      [userId, date],
+    );
+
+    for (const row of todayReviews) {
+      items.push({
+        type: 'review',
+        priority: 2,
+        studySetId: row.study_set_id,
+        studySetName: row.study_set_name,
+        detail: `${row.due_count} review(s) due today`,
+        count: parseInt(row.due_count, 10),
+      });
+    }
+
+    // 3. Exam dates for the given date
+    const exams = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      exam_date: string;
+    }>(
+      `SELECT
+        e.study_set_id,
+        s.title AS study_set_name,
+        e.exam_date::TEXT
+      FROM study_set_exam_dates e
+      JOIN study_sets s ON e.study_set_id = s.id
+      WHERE e.user_id = $1
+        AND e.exam_date = $2::DATE`,
+      [userId, date],
+    );
+
+    for (const row of exams) {
+      items.push({
+        type: 'exam',
+        priority: 0,
+        studySetId: row.study_set_id,
+        studySetName: row.study_set_name,
+        detail: `Exam scheduled`,
+        examDate: row.exam_date,
+      });
+    }
+
+    // Sort by priority (lower number = higher priority)
+    items.sort((a, b) => a.priority - b.priority);
+
+    return items;
+  }
+
+  /**
+   * Set an exam date for a study set
+   */
+  async setExamDate(
+    userId: string,
+    studySetId: string,
+    examDate: string,
+  ): Promise<ExamDateRecord> {
+    // Upsert: if exam date already exists for this user+study_set, update it
+    const result = await this.db.queryOne<{
+      id: string;
+      user_id: string;
+      study_set_id: string;
+      exam_date: string;
+      created_at: Date;
+    }>(
+      `INSERT INTO study_set_exam_dates (user_id, study_set_id, exam_date)
+      VALUES ($1, $2, $3::DATE)
+      ON CONFLICT (user_id, study_set_id)
+      DO UPDATE SET exam_date = $3::DATE
+      RETURNING id, user_id, study_set_id, exam_date::TEXT, created_at`,
+      [userId, studySetId, examDate],
+    );
+
+    if (!result) {
+      throw new Error('Failed to set exam date');
+    }
+
+    return {
+      id: result.id,
+      userId: result.user_id,
+      studySetId: result.study_set_id,
+      examDate: result.exam_date,
+      createdAt: result.created_at,
+    };
+  }
+
+  /**
+   * Get study streak and calendar heatmap data for the last 90 days
+   */
+  async getStudyStreak(userId: string): Promise<StudyStreakData> {
+    // Get flashcard review activity per day for the last 90 days
+    const activity = await this.db.queryMany<{
+      activity_date: string;
+      review_count: string;
+    }>(
+      `SELECT
+        DATE(f.last_reviewed_at) AS activity_date,
+        COUNT(f.id) AS review_count
+      FROM flashcards f
+      JOIN study_sets s ON f.study_set_id = s.id
+      WHERE s.user_id = $1
+        AND f.last_reviewed_at >= NOW() - INTERVAL '90 days'
+        AND f.last_reviewed_at IS NOT NULL
+      GROUP BY DATE(f.last_reviewed_at)
+      ORDER BY activity_date ASC`,
+      [userId],
+    );
+
+    const heatmap = activity.map((a) => ({
+      date: a.activity_date,
+      count: parseInt(a.review_count, 10),
+    }));
+
+    // Calculate streaks
+    const { current, longest } = this.calculateStreak(heatmap);
+
+    return {
+      currentStreak: current,
+      longestStreak: longest,
+      heatmap,
+    };
+  }
+
+  /**
+   * Export upcoming reviews and exam dates as iCal (.ics) file
+   */
+  async exportToIcal(userId: string): Promise<string> {
+    // Get upcoming reviews for the next 30 days
+    const upcoming = await this.getUpcomingReviews(userId, 30);
+
+    // Get all exam dates
+    const exams = await this.db.queryMany<{
+      study_set_id: string;
+      study_set_name: string;
+      exam_date: string;
+    }>(
+      `SELECT
+        e.study_set_id,
+        s.title AS study_set_name,
+        e.exam_date::TEXT
+      FROM study_set_exam_dates e
+      JOIN study_sets s ON e.study_set_id = s.id
+      WHERE e.user_id = $1
+        AND e.exam_date >= CURRENT_DATE`,
+      [userId],
+    );
+
+    const lines: string[] = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//Studyield//Study Planner//EN',
+      'CALSCALE:GREGORIAN',
+      'METHOD:PUBLISH',
+    ];
+
+    // Add review sessions
+    for (const day of upcoming) {
+      const dateCompact = day.date.replace(/-/g, '');
+      const setNames = day.studySets.map((s) => s.name).join(', ');
+      lines.push('BEGIN:VEVENT');
+      lines.push(`DTSTART;VALUE=DATE:${dateCompact}`);
+      lines.push(`DTEND;VALUE=DATE:${dateCompact}`);
+      lines.push(`SUMMARY:${day.reviewCount} flashcard review(s) due`);
+      lines.push(`DESCRIPTION:Study sets: ${this.escapeIcal(setNames)}`);
+      lines.push(`UID:review-${dateCompact}-${userId}@studyield`);
+      lines.push('END:VEVENT');
+    }
+
+    // Add exam dates
+    for (const exam of exams) {
+      const dateCompact = exam.exam_date.replace(/-/g, '');
+      lines.push('BEGIN:VEVENT');
+      lines.push(`DTSTART;VALUE=DATE:${dateCompact}`);
+      lines.push(`DTEND;VALUE=DATE:${dateCompact}`);
+      lines.push(`SUMMARY:Exam: ${this.escapeIcal(exam.study_set_name)}`);
+      lines.push(`DESCRIPTION:Exam for study set: ${this.escapeIcal(exam.study_set_name)}`);
+      lines.push(`UID:exam-${exam.study_set_id}-${dateCompact}@studyield`);
+      lines.push('END:VEVENT');
+    }
+
+    lines.push('END:VCALENDAR');
+
+    return lines.join('\r\n');
+  }
+
+  private escapeIcal(text: string): string {
+    return text
+      .replace(/\\/g, '\\\\')
+      .replace(/;/g, '\\;')
+      .replace(/,/g, '\\,')
+      .replace(/\n/g, '\\n');
+  }
+
+  private calculateStreak(
+    activity: Array<{ date: string; count: number }>,
+  ): { current: number; longest: number } {
+    if (activity.length === 0) return { current: 0, longest: 0 };
+
+    let current = 0;
+    let longest = 0;
+    let streak = 0;
+    let lastDate: Date | null = null;
+
+    const sorted = [...activity].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+
+    for (const a of sorted) {
+      if (a.count === 0) continue;
+      const date = new Date(a.date);
+      if (lastDate) {
+        const diff = Math.floor(
+          (date.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        if (diff === 1) {
+          streak++;
+        } else {
+          longest = Math.max(longest, streak);
+          streak = 1;
+        }
+      } else {
+        streak = 1;
+      }
+      lastDate = date;
+    }
+
+    longest = Math.max(longest, streak);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (lastDate) {
+      lastDate.setHours(0, 0, 0, 0);
+      const diff = Math.floor(
+        (today.getTime() - lastDate.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      current = diff <= 1 ? streak : 0;
+    }
+
+    return { current, longest };
+  }
+}


### PR DESCRIPTION
## Summary
- Add `StudyPlannerModule` with service and controller for study planning features
- Endpoints: upcoming reviews, daily plan, exam date setting, study streak/heatmap, iCal export
- Add `study_set_exam_dates` migration table with unique constraint per user+study_set

Closes #55

## Test plan
- [ ] `GET /study-planner/upcoming?days=14` returns flashcard reviews grouped by date
- [ ] `GET /study-planner/daily?date=2026-04-12` returns prioritized daily plan (overdue > due today > exams)
- [ ] `POST /study-planner/exam-date` sets/updates exam date for a study set (upsert behavior)
- [ ] `GET /study-planner/streak` returns current/longest streak and 90-day heatmap
- [ ] `GET /study-planner/export/ical` returns valid .ics file with review sessions and exam events
- [ ] Run migration `015_study_set_exam_dates.sql` and verify table creation with indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)